### PR TITLE
refactor: extract waker module, prepare to port thread waker in the future

### DIFF
--- a/src/runtime/core/mod.rs
+++ b/src/runtime/core/mod.rs
@@ -3,4 +3,3 @@ pub mod spawner;
 
 pub(crate) mod reactor;
 pub(crate) mod task;
-pub(crate) mod waker;

--- a/src/runtime/core/task.rs
+++ b/src/runtime/core/task.rs
@@ -5,7 +5,9 @@ use std::{
     task::{RawWaker, Waker},
 };
 
-use super::{spawner::Spawner, waker::get_waker_vtable};
+use crate::runtime::waker::reactor_waker::get_waker_vtable;
+
+use super::spawner::Spawner;
 
 /// a task is a pinned future that is to be polled by the executor
 pub struct Task {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@ use self::core::{executor::Executor, spawner::Spawner};
 
 pub mod core;
 pub mod futures;
+pub(crate) mod waker;
 
 pub fn new_executor_spawner() -> (Executor, Spawner) {
     const MAX_QUEUED_TASKS: usize = 10_000;

--- a/src/runtime/waker/mod.rs
+++ b/src/runtime/waker/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod reactor_waker;

--- a/src/runtime/waker/reactor_waker.rs
+++ b/src/runtime/waker/reactor_waker.rs
@@ -3,7 +3,7 @@ use std::{
     task::{RawWaker, RawWakerVTable},
 };
 
-use super::task::Task;
+use crate::runtime::core::task::Task;
 
 const WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
 


### PR DESCRIPTION
As of now, there are cycle dependencies between task and waker module. This is to be address in the future as well.